### PR TITLE
chore: update repo urls and author details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.2.1](https://github.com/Jmsa/eslint-formatter-ratchet/compare/v1.2.0...v1.2.1) (2024-08-23)
+
 ## [1.2.0](https://github.com/Jmsa/eslint-formatter-ratchet/compare/v1.1.0...v1.2.0) (2023-08-21)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,48 +2,48 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [1.2.0](https://github.com/ProductPlan/eslint-formatter-ratchet/compare/v1.1.0...v1.2.0) (2023-08-21)
+## [1.2.0](https://github.com/Jmsa/eslint-formatter-ratchet/compare/v1.1.0...v1.2.0) (2023-08-21)
 
 ### Features
 
-- add support for bypassing eslint erroring on rule violations ([f30e08c](https://github.com/ProductPlan/eslint-formatter-ratchet/commit/f30e08cac2afc1929a9af2e0a5a8f8b5e915932c))
+- add support for bypassing eslint erroring on rule violations ([f30e08c](https://github.com/Jmsa/eslint-formatter-ratchet/commit/f30e08cac2afc1929a9af2e0a5a8f8b5e915932c))
 
 ### Bug Fixes
 
-- use the `logger` instead of `console` ([5647a52](https://github.com/ProductPlan/eslint-formatter-ratchet/commit/5647a52fedd922a4d7e70f9c5d61dbde12858698))
+- use the `logger` instead of `console` ([5647a52](https://github.com/Jmsa/eslint-formatter-ratchet/commit/5647a52fedd922a4d7e70f9c5d61dbde12858698))
 
-## [1.1.0](https://github.com/ProductPlan/eslint-formatter-ratchet/compare/v1.0.4...v1.1.0) (2023-01-06)
+## [1.1.0](https://github.com/Jmsa/eslint-formatter-ratchet/compare/v1.0.4...v1.1.0) (2023-01-06)
 
 ### Features
 
-- use eslint-formatter-table to log issues ([10540b0](https://github.com/ProductPlan/eslint-formatter-ratchet/commit/10540b0910c920fa9776efe8a5f0d9e2e6574daa))
+- use eslint-formatter-table to log issues ([10540b0](https://github.com/Jmsa/eslint-formatter-ratchet/commit/10540b0910c920fa9776efe8a5f0d9e2e6574daa))
 
-### [1.0.4](https://github.com/ProductPlan/eslint-formatter-ratchet/compare/v1.0.3...v1.0.4) (2022-03-17)
-
-### Bug Fixes
-
-- use relative paths in eslint-ratchet file ([dd6e19b](https://github.com/ProductPlan/eslint-formatter-ratchet/commit/dd6e19b58e700a94fdc33b31b81557a3d701d9cd))
-
-### [1.0.3](https://github.com/ProductPlan/eslint-formatter-ratchet/compare/v1.0.2...v1.0.3) (2022-03-12)
+### [1.0.4](https://github.com/Jmsa/eslint-formatter-ratchet/compare/v1.0.3...v1.0.4) (2022-03-17)
 
 ### Bug Fixes
 
-- better missing file handling, improved `hasChanged` checks, better resolved rule clean up ([f0ea940](https://github.com/ProductPlan/eslint-formatter-ratchet/commit/f0ea940c7d99a19337ef32b675c385121ef76cda))
+- use relative paths in eslint-ratchet file ([dd6e19b](https://github.com/Jmsa/eslint-formatter-ratchet/commit/dd6e19b58e700a94fdc33b31b81557a3d701d9cd))
 
-### [1.0.2](https://github.com/ProductPlan/eslint-formatter-ratchet/compare/v1.0.1...v1.0.2) (2022-03-11)
-
-### Bug Fixes
-
-- make sure to use `log` from the provided logger ([6c9f642](https://github.com/ProductPlan/eslint-formatter-ratchet/commit/6c9f64215d98f751b49292e8487a7300d184b47d))
-
-### [1.0.1](https://github.com/ProductPlan/eslint-formatter-ratchet/compare/v1.0.0...v1.0.1) (2022-03-10)
+### [1.0.3](https://github.com/Jmsa/eslint-formatter-ratchet/compare/v1.0.2...v1.0.3) (2022-03-12)
 
 ### Bug Fixes
 
-- removed files should update the thresholds ([26752eb](https://github.com/ProductPlan/eslint-formatter-ratchet/commit/26752ebb514cf7be5fd0ab8a6fe130faccba4181)), closes [#2](https://github.com/ProductPlan/eslint-formatter-ratchet/issues/2)
+- better missing file handling, improved `hasChanged` checks, better resolved rule clean up ([f0ea940](https://github.com/Jmsa/eslint-formatter-ratchet/commit/f0ea940c7d99a19337ef32b675c385121ef76cda))
+
+### [1.0.2](https://github.com/Jmsa/eslint-formatter-ratchet/compare/v1.0.1...v1.0.2) (2022-03-11)
+
+### Bug Fixes
+
+- make sure to use `log` from the provided logger ([6c9f642](https://github.com/Jmsa/eslint-formatter-ratchet/commit/6c9f64215d98f751b49292e8487a7300d184b47d))
+
+### [1.0.1](https://github.com/Jmsa/eslint-formatter-ratchet/compare/v1.0.0...v1.0.1) (2022-03-10)
+
+### Bug Fixes
+
+- removed files should update the thresholds ([26752eb](https://github.com/Jmsa/eslint-formatter-ratchet/commit/26752ebb514cf7be5fd0ab8a6fe130faccba4181)), closes [#2](https://github.com/Jmsa/eslint-formatter-ratchet/issues/2)
 
 ## 1.0.0 (2022-03-08)
 
 ### Features
 
-- initial port ([00e9ded](https://github.com/ProductPlan/eslint-formatter-ratchet/commit/00e9ded062bfefcaf45385aaccadb718673ceed5))
+- initial port ([00e9ded](https://github.com/Jmsa/eslint-formatter-ratchet/commit/00e9ded062bfefcaf45385aaccadb718673ceed5))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-formatter-ratchet",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "index.js",
   "repository": "https://github.com/Jmsa/eslint-formatter-ratchet.git",
   "description": "Ratcheting applied to ESLint results so new issues don't creep in.",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "eslint-formatter-ratchet",
   "version": "1.2.0",
   "main": "index.js",
-  "repository": "https://github.com/ProductPlan/eslint-formatter-ratchet.git",
+  "repository": "https://github.com/Jmsa/eslint-formatter-ratchet.git",
   "description": "Ratcheting applied to ESLint results so new issues don't creep in.",
-  "author": "James Abercrombie <james@productplan.com>",
+  "author": "James Abercrombie <jmsabercrombie88@gmail.com>",
   "license": "MIT",
   "keywords": [
     "eslint",


### PR DESCRIPTION
### SUMMARY:

These were simply missed during the ownership transfer so just doing a bit of clean up. Technically github resolves to the correct locations anyway, but better safe than sorry, especially if ProductPlan ever decides to fork the repo down the line.

As a result of these changes the following should happen:
- npm registries(like npm.js) should eventually have updated links to the non productplan repo
- anyone trying to contact me via the author email actually can (since it's my personal email)
- codeclimate _should_ automatically update its repo name 🤞 (this is locked otherwise)

_Note: These changes may result in breaking the badges displayed in the readme but if that happens they'll get replaced in a follow up._

