### PR TITLE
chore: Update GitHub Actions cache action to v4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: "18"
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION

### SUMMARY:

V2 was deprecated at the end of 2024 and shutdown completely on March 1st which is now resulting in failed action runs. Bumping to the latest per the migration details in the [deprecation notice](https://github.com/actions/cache/discussions/1510).

### TESTING NOTES:

Successful action runs (which run tests) are expected before merging:
- A previously failing run => [13645318478](https://github.com/Jmsa/eslint-formatter-ratchet/actions/runs/13645318478)
- An updated passing run => [13647693171](https://github.com/Jmsa/eslint-formatter-ratchet/actions/runs/13647693171)

### SCREENSHOTS OR IT DIDN'T HAPPEN:

<img width="1496" alt="Screenshot 2025-03-03 at 10 36 29 PM" src="https://github.com/user-attachments/assets/53ee8563-7918-4b6b-8525-7c7db6a98704" />

