### PR TITLE
chore: only upload coverage reports to Codecov on main branch

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,6 +46,7 @@ jobs:
           coverageCommand: yarn test:ci
           coverageLocations: ${{github.workspace}}/coverage/lcov.info:lcov
       - name: Upload coverage reports to Codecov
+        if: github.ref == 'refs/heads/main'
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION

### SUMMARY:

There's no good reason to upload coverage for individual branches at this point so adding a condition to the job that will only upload for `main`.

### TESTING NOTES:

There's only a few possible cases here:
- test runs on `main` upload results to Codecov 
- test runs on any other branch do not upload to Codecov

### SCREENSHOTS OR IT DIDN'T HAPPEN:

It happened...
