### PR TITLE
Change Object.assign to structuredClone, add test

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ const detectAndLogChanges = (
   // Keep track of any new issues - where the counts for a previously reported
   // issue have gone up
   let newIssues = 0;
-  const updatedResults = Object.assign({}, previousResults);
+  const updatedResults = structuredClone(previousResults);
 
   Object.entries({ added, updated, deleted }).forEach(([setKey, set]) => {
     Object.entries(set).forEach(([fileKey, fileValue]) => {

--- a/index.test.js
+++ b/index.test.js
@@ -5,6 +5,7 @@ const mock = require("mock-fs");
 const formatter = require("./index");
 const sinon = require("sinon");
 
+chai.config.truncateThreshold = 0;
 let messages = [];
 const logger = {
   log: (m) => messages.push(m),
@@ -186,6 +187,49 @@ describe("eslint-ratchet", () => {
     expectedMessages.forEach((message) => expect(messages).to.contain(message));
     restoreMocks();
   });
+
+  it("sees completely new errors as regressions", () => {
+    const newResults = getMockResults();
+    newResults[1].errorCount++;
+    newResults[1].messages.push({
+      ruleId: "test/new-error",
+      severity: 2
+    });
+    const expectedLatest = {
+      "some/path/file-a.jsx": {
+        "react/jsx-no-target-blank": {
+          warning: 0,
+          error: 2,
+        },
+        "test/new-error": {
+          warning: 0,
+          error: 1,
+        }
+      },
+      "another/path/file-b.js": {
+        "@productplan/custom-rules/throw-or-log": {
+          warning: 2,
+          error: 0,
+        },
+      },
+    };
+    const expectedMessages = [
+      "⚠️  eslint-ratchet: Changes to eslint results detected!!!",
+      "some/path/file-a.jsx",
+      "test/new-error",
+      "--> error: 1 (previously: 0)",
+      "🔥",
+      "These latest eslint results have been saved to eslint-ratchet-temp.json. \nIf these results were expected then use them to replace the content of eslint-ratchet.json and check it in.",
+    ];
+
+    setupMocks();
+    expect(() => formatter(newResults, null, logger)).to.throw();
+    expectedMessages.forEach((message) => expect(messages).to.contain(message));
+
+    const newValues = JSON.parse(fs.readFileSync("./eslint-ratchet-temp.json"));
+    expect(JSON.stringify(newValues)).to.equal(JSON.stringify(expectedLatest));
+    restoreMocks();
+  })
 
   describe("option: RATCHET_DEFAULT_EXIT_ZERO", () => {
     it("disabled: does not log", () => {


### PR DESCRIPTION
### SUMMARY:

- By using `Object.assign` to create the "updated results" object, changes made to referenced objects affect the original object as `Object.assign` only does top-level reference copying. By using `structuredClone` we copy all values and no contamination of the original values is allowed.
- This was a problem when a completely new error appeared, as the `previousValue` would end up being `undefined`, and neither branch of the `if/else if` would run meaning a new error would not increment `newIssues` or be logged. This resulted in very confusing output where new errors were mentioned but ratchet insisted they were "improvements":

```
  src\app\shared\top-navigation\top-navigation.component.html
    @angular-eslint/template/prefer-control-flow
  Changes found are all improvements! These new results have been saved to eslint-ratchet.json
```

### TESTING NOTES:

- Added a new test to cover this gap which tests what happens when a new error shows up as opposed to just incrementing an existing error count.

### SCREENSHOTS OR IT DIDN'T HAPPEN:

![image](https://github.com/user-attachments/assets/9adfb6ce-9240-41bf-afa3-847c3c2e62ce)

